### PR TITLE
Updates 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
-import com.trueaccord.scalapb.{ScalaPbPlugin => PB}
+import com.trueaccord.scalapb.compiler.Version.scalapbVersion
 
-name := "akka-persistence"
-version := "1.0"
-scalaVersion := "2.11.8"
+name := "akka-persistence-example-with-protocol-buffers"
+version := "1.1"
+scalaVersion := "2.12.1"
 
 // Disable parallel execution of tests
 parallelExecution in Test := false
@@ -14,29 +14,27 @@ libraryDependencies ++= {
   val akkaVersion       = "2.4.16"
   Seq(
     // Akka
-    "com.typesafe.akka"           %% "akka-actor"       % akkaVersion,
-    "com.typesafe.akka"           %% "akka-persistence" % akkaVersion,
-    "com.typesafe.akka"           %% "akka-testkit"     % akkaVersion   % "test",
-    "com.typesafe.akka"           %% "akka-slf4j"       % akkaVersion,
-    "com.typesafe.akka"           %% "akka-persistence-query-experimental" % akkaVersion,
+    "com.typesafe.akka"           %% "akka-actor"                           % akkaVersion,
+    "com.typesafe.akka"           %% "akka-persistence"                     % akkaVersion,
+    "com.typesafe.akka"           %% "akka-testkit"                         % akkaVersion   % "test",
+    "com.typesafe.akka"           %% "akka-slf4j"                           % akkaVersion,
+    "com.typesafe.akka"           %% "akka-persistence-query-experimental"  % akkaVersion,
 
-    // Local journal (Akka Persistence)
-    // http://doc.akka.io/docs/akka/2.4.8/scala/persistence.html#Local_LevelDB_journal
-    "org.iq80.leveldb"            % "leveldb"          % "0.9",
-    "org.fusesource.leveldbjni"   % "leveldbjni-all"   % "1.8",
+    // Local LevelDB journal (Akka Persistence)
+    // http://doc.akka.io/docs/akka/current/scala/persistence.html#Local_LevelDB_journal
+    "org.iq80.leveldb"            % "leveldb"           % "0.9",
+    "org.fusesource.leveldbjni"   % "leveldbjni-all"    % "1.8",
 
     // Commons IO is needed for cleaning up data when testing persistent actors
     "commons-io"                  %  "commons-io"       % "2.4",
     "ch.qos.logback"              %  "logback-classic"  % "1.1.3",
-    "org.scalatest"               %% "scalatest"        % "2.2.6"       % "test",
+    "org.scalatest"               %% "scalatest"        % "3.0.1"         % "test",
 
     // allows ScalaPB proto customizations (scalapb/scalapb.proto)
-    "com.trueaccord.scalapb"      %% "scalapb-runtime"  % "0.5.34"       % PB.protobufConfig
+    "com.trueaccord.scalapb"      %% "scalapb-runtime"  % scalapbVersion  % "protobuf"
   )
 }
 
-PB.protobufSettings
-PB.runProtoc in PB.protobufConfig := {
-  args => com.github.os72.protocjar.Protoc.runProtoc("-v300" +: args.toArray)
-}
-version in PB.protobufConfig := "3.0.0-beta-3"
+PB.targets in Compile := Seq(
+  scalapb.gen() -> (sourceManaged in Compile).value
+)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.11
+sbt.version = 0.13.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,9 @@
 logLevel := Level.Warn
 
 // Informative Scala compiler errors
-addSbtPlugin("com.softwaremill.clippy" % "plugin-sbt" % "0.3.0")
+addSbtPlugin("com.softwaremill.clippy" % "plugin-sbt" % "0.4.1")
 
 // Scala Protocol Buffers Compiler
-addSbtPlugin("com.trueaccord.scalapb" % "sbt-scalapb" % "0.5.34")
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.3")
 
-// Protoc-jar so we don't need the Protoc compiler
-libraryDependencies += "com.github.os72" % "protoc-jar" % "3.0.0-b3"
+libraryDependencies += "com.trueaccord.scalapb" %% "compilerplugin" % "0.5.47"

--- a/src/main/protobuf/models.proto
+++ b/src/main/protobuf/models.proto
@@ -1,28 +1,29 @@
-syntax = "proto2";
+syntax = "proto3";
 
-// This is available because of the PB.protobufConfig on scalapb-runtime in build.sbt
+// Brought in from scalapb-runtime
 import "scalapb/scalapb.proto";
+import "google/protobuf/wrappers.proto";
 
 package com.experiments.calculator;
 
 message Added {
     option (scalapb.message).extends = "com.experiments.calculator.models.Models.Event";
-    required double value = 1;
+    double value = 1;
 }
 
 message Subtracted {
     option (scalapb.message).extends = "com.experiments.calculator.models.Models.Event";
-    required double value = 1;
+    double value = 1;
 }
 
 message Multiplied {
     option (scalapb.message).extends = "com.experiments.calculator.models.Models.Event";
-    required double value = 1;
+    double value = 1;
 }
 
 message Divided {
     option (scalapb.message).extends = "com.experiments.calculator.models.Models.Event";
-    required double value = 1;
+    double value = 1;
 }
 
 message Reset {


### PR DESCRIPTION
- Update SBT to 0.13.13
- Update Scala to 2.12.1
- Update Akka-* to 2.4.16
- Update ScalaTest to 3.0.1
- Move to new ScalaPB compiler
- Remove external Protocol Buffers jar since this is no longer needed
- Update proto models to version 3

Completes https://github.com/calvinlfer/Akka-Persistence-example-with-Protocol-Buffers-serialization/issues/2